### PR TITLE
Add plugin version checker and dry-run install

### DIFF
--- a/.github/workflows/playbook-ci.yml
+++ b/.github/workflows/playbook-ci.yml
@@ -27,6 +27,11 @@ jobs:
           python3 -m json.tool plugins/scientific-house-style/.claude-plugin/plugin.json >/dev/null
           python3 -m json.tool plugins/scientific-plan-execute/hooks/hooks.json >/dev/null
 
+      - name: Plugin version consistency
+        run: |
+          set -euo pipefail
+          bash scripts/check-plugin-versions.sh
+
       - name: Repository contract checks
         run: |
           set -euo pipefail
@@ -105,3 +110,12 @@ jobs:
           test -f "$codex_home_house/skills/jax-project-engineering/SKILL.md"
           test ! -d "$codex_home_house/skills/howto-functional-vs-imperative"
           test ! -d "$codex_home_house/skills/starting-a-design-plan"
+
+      - name: Dry-run install smoke test
+        run: |
+          set -euo pipefail
+          output=$(bash scripts/install-codex-home.sh --dry-run)
+          echo "$output"
+          echo "$output" | grep -q "\[dry-run\]"
+          echo "$output" | grep -q "scientific-plan-execute"
+          echo "$output" | grep -q "No files were modified"

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Check that all plugin versions are consistent and valid semver.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+TMPFILE=/tmp/plugin-versions-$$
+
+cleanup() {
+  rm -f $TMPFILE
+}
+
+trap cleanup EXIT
+
+errors=0
+
+check_semver() {
+  local version=$1
+  local name=$2
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: $name has invalid semver: $version" >&2
+    errors=$((errors + 1))
+  fi
+}
+
+# Extract versions from all plugin manifests
+for manifest in $(find $repo_root/plugins -name "plugin.json" -type f); do
+  plugin_name=$(basename $(dirname $(dirname $manifest)))
+  version=$(python3 -c "import json; print(json.load(open('$manifest'))['version'])")
+  echo "$plugin_name=$version" >> $TMPFILE
+  check_semver $version $plugin_name
+done
+
+# Extract marketplace versions
+marketplace="${repo_root}/.claude-plugin/marketplace.json"
+if [ -f "$marketplace" ]; then
+  python3 -c "
+import json
+data = json.load(open('$marketplace'))
+for p in data.get('plugins', []):
+    print(f\"{p['name']}={p['version']}\")
+" >> $TMPFILE
+fi
+
+# Check all versions match
+versions=$(cat $TMPFILE | cut -d= -f2 | sort -u)
+count=$(echo "$versions" | wc -l | tr -d ' ')
+
+if [ "$count" -ne 1 ]; then
+  echo "error: version mismatch detected:" >&2
+  cat $TMPFILE | sort >&2
+  errors=$((errors + 1))
+fi
+
+if [ $errors -gt 0 ]; then
+  echo "FAIL: $errors version errors found" >&2
+  exit 1
+fi
+
+echo "OK: all plugin versions consistent ($(head -1 $TMPFILE | cut -d= -f2))"

--- a/scripts/install-codex-home.sh
+++ b/scripts/install-codex-home.sh
@@ -27,7 +27,7 @@ done < <(ssp_valid_plugins)
 
 usage() {
   cat <<USAGE
-Usage: scripts/install-codex-home.sh [--codex-home <path>] [--plugin <name>] [--force]
+Usage: scripts/install-codex-home.sh [--codex-home <path>] [--plugin <name>] [--force] [--dry-run]
 
 Installs playbook plugins into Codex home:
 1. Skills -> <codex-home>/skills/
@@ -37,6 +37,7 @@ Options:
   --codex-home <path>  Override CODEX_HOME (default: \$CODEX_HOME or ~/.codex)
   --plugin <name>      Plugin to install (repeatable). Default: all plugins
   --force              Overwrite existing installed playbook bundle
+  --dry-run            Print what would be installed without making changes
 
 Available plugins:
 USAGE
@@ -57,6 +58,7 @@ is_valid_plugin() {
 
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 force=0
+dry_run=0
 selected_plugins=()
 
 while [[ $# -gt 0 ]]; do
@@ -86,6 +88,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --force)
       force=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
       shift
       ;;
     -h|--help)
@@ -128,6 +134,20 @@ fi
 if [[ ! -d "$plugins_src_root" ]]; then
   echo "error: missing plugins directory at $plugins_src_root" >&2
   exit 1
+fi
+
+if [[ "$dry_run" -eq 1 ]]; then
+  echo "[dry-run] Would install to: ${codex_home}"
+  echo "[dry-run] Plugins:"
+  for plugin in "${selected_plugins[@]}"; do
+    echo "  - ${plugin}"
+    while IFS= read -r skill; do
+      [[ -n "$skill" ]] || continue
+      echo "    skill: ${skill}"
+    done < <(ssp_plugin_skills "$plugin")
+  done
+  echo "[dry-run] No files were modified."
+  exit 0
 fi
 
 skills_dst="${codex_home}/skills"


### PR DESCRIPTION
## Summary
- Add `scripts/check-plugin-versions.sh` — standalone script to validate all plugin manifests have consistent semver versions matching the marketplace manifest
- Add `--dry-run` flag to `scripts/install-codex-home.sh` to preview what would be installed without making changes
- Wire both into the CI pipeline as new verification steps

## Details

### Version checker (`scripts/check-plugin-versions.sh`)
Extracts versions from all `plugin.json` manifests and the marketplace manifest, validates semver format, and checks consistency. Intended to catch version drift before it reaches users.

### Dry-run install
The `--dry-run` flag prints the target directory, selected plugins, and associated skills, then exits without modifying the filesystem. Useful for debugging install issues or verifying plugin selection logic.

### CI additions
- "Plugin version consistency" step runs the new version checker after JSON validation
- "Dry-run install smoke test" verifies the `--dry-run` flag produces expected output

## Test plan
- [ ] Run `bash scripts/check-plugin-versions.sh` locally and confirm it reports OK
- [ ] Run `bash scripts/install-codex-home.sh --dry-run` and confirm no files are created
- [ ] Run `bash scripts/install-codex-home.sh --dry-run --plugin scientific-research` and confirm only research plugin is listed
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)